### PR TITLE
#166 adding partner id as accessible via header

### DIFF
--- a/backend/unpp_api/apps/common/middleware.py
+++ b/backend/unpp_api/apps/common/middleware.py
@@ -1,0 +1,24 @@
+from django.utils.functional import SimpleLazyObject
+
+from partner.models import Partner
+
+
+def get_actual_value(request):
+    partner_id = request.META.get('HTTP_ACTIVE_PARTNER', None)
+
+    if partner_id:
+        try:
+            return Partner.objects.get(id=partner_id)
+        except Partner.DoesNotExist:
+            return None
+
+    return None
+
+class ActivePartnerMiddlewware(object):
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        request.active_partner = SimpleLazyObject(lambda: get_actual_value(request))
+        response = self.get_response(request)
+        return response

--- a/backend/unpp_api/settings/base.py
+++ b/backend/unpp_api/settings/base.py
@@ -76,12 +76,13 @@ DATABASES = {
     }
 }
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
+    'common.middleware.ActivePartnerMiddlewware',
 ]
 
 TEMPLATES = [


### PR DESCRIPTION
This is needed for the scenario where the HQ user is toggling through different partners they have.

This allow for the frontend to send the partner id in the request header as `Partner-ID`. cc @marcindo @kenzo23312 

@lkolacz this will allow us to access partner (if it exists) in the request object. 