### PR TITLE
django.log removed - all logs sent to stdout

### DIFF
--- a/backend/unpp_api/settings/base.py
+++ b/backend/unpp_api/settings/base.py
@@ -184,11 +184,8 @@ LOGGING = {
     'handlers': {
         'default': {
             'level': 'DEBUG',
-            'class': 'common.utils.DeferredRotatingFileHandler',
-            'filename': 'django.log',  # Full path is created by DeferredRotatingFileHandler.
-            'maxBytes': 1024*1024*5,  # 5 MB
-            'backupCount': 5,
-            'formatter': 'standard'
+            'class': 'logging.StreamHandler',
+            'formatter': 'standard',
         },
         'mail_admins': {
             'level': 'ERROR',


### PR DESCRIPTION
As we don't use volumes, we don't need django.log file. I've modified handler to sent logs to stdout and to external log collector as an effect (papertrail for now)