### PR TITLE
#235 - current user account (/me) view

### DIFF
--- a/backend/unpp_api/apps/account/models.py
+++ b/backend/unpp_api/apps/account/models.py
@@ -15,6 +15,26 @@ class User(AbstractUser):
     def __str__(self):
         return "{} - User".format(self.get_fullname())
 
+    @property
+    def is_agency_user(self):
+        return self.agency_members.exists()
+
+    @property
+    def is_partner_user(self):
+        return self.partner_members.exists()
+
+    def get_partner_ids_i_can_access(self):
+        # Returns country partners if member of HQ (since no db relation there)
+        partner_members = self.partner_members.all()
+        partner_ids = []
+        for partner_member in partner_members:
+            partner_ids.append(partner_member.partner.id)
+            if partner_member.partner.is_hq:
+                partner_ids.extend(
+                    [p.id for p in partner_member.partner.country_profiles])
+
+        return partner_ids
+
     def get_fullname(self):
         return self.username
 

--- a/backend/unpp_api/apps/account/serializers.py
+++ b/backend/unpp_api/apps/account/serializers.py
@@ -98,3 +98,51 @@ class PartnerRegistrationSerializer(serializers.Serializer):
             "partner_member": PartnerMemberSerializer(instance=self.partner_member).data,
         }
         return self.instance_json
+
+
+class UserSerializer(serializers.ModelSerializer):
+
+    name = serializers.CharField(source='get_fullname')
+
+    class Meta:
+        model = User
+        fields = ('id', 'name', 'email',)
+
+
+class AgencyUserSerializer(UserSerializer):
+
+    agency_name = serializers.SerializerMethodField()
+    office_name = serializers.SerializerMethodField()
+    role = serializers.SerializerMethodField()
+
+    class Meta:
+        model = User
+        fields = UserSerializer.Meta.fields + ('agency_name',
+                                               'role',
+                                               'office_name',)
+
+    def _agency_member(self, obj):
+        return obj.agency_members.get()
+
+    def get_role(self, obj):
+        return self._agency_member(obj).get_role_display()
+
+    def get_agency_name(self, obj):
+        return self._agency_member(obj).office.agency.name
+
+    def get_office_name(self, obj):
+        return self._agency_member(obj).office.name
+
+
+class PartnerUserSerializer(UserSerializer):
+
+    partners = serializers.SerializerMethodField()
+
+    class Meta:
+        model = User
+        fields = UserSerializer.Meta.fields + ('partners',)
+
+    def get_partners(self, obj):
+        partner_ids = obj.get_partner_ids_i_can_access()
+        return PartnerSerializer(Partner.objects.filter(id__in=partner_ids),
+                                 many=True).data

--- a/backend/unpp_api/apps/account/urls.py
+++ b/backend/unpp_api/apps/account/urls.py
@@ -1,8 +1,9 @@
 from django.conf.urls import url
 
-from .views import AccountRegisterAPIView
+from .views import AccountRegisterAPIView, AccountCurrentUserRetrieveAPIView
 
 
 urlpatterns = [
     url(r'^registration$', AccountRegisterAPIView.as_view(), name="registration"),
+    url(r'^me/$', AccountCurrentUserRetrieveAPIView.as_view(), name="my-account"),
 ]

--- a/backend/unpp_api/apps/account/views.py
+++ b/backend/unpp_api/apps/account/views.py
@@ -1,14 +1,19 @@
 import logging
 
 from django.contrib.auth import authenticate, login, logout
+from django.http import Http404
+
 from rest_framework import status as statuses
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from rest_framework.permissions import AllowAny
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.generics import RetrieveAPIView
 
 from .serializers import (
     RegisterSimpleAccountSerializer,
     PartnerRegistrationSerializer,
+    AgencyUserSerializer,
+    PartnerUserSerializer,
 )
 
 logger = logging.getLogger(__name__)
@@ -30,3 +35,18 @@ class AccountRegisterAPIView(APIView):
 
         serializer.save()
         return Response(serializer.instance_json, status=statuses.HTTP_201_CREATED)
+
+
+class AccountCurrentUserRetrieveAPIView(RetrieveAPIView):
+    permission_classes = (IsAuthenticated, )
+
+    def get_serializer_class(self):
+        if self.request.user.is_agency_user:
+            return AgencyUserSerializer
+        if self.request.user.is_partner_user:
+            return PartnerUserSerializer
+        raise Http404('User has no relation to agency or partners')
+
+
+    def get_object(self):
+        return self.request.user

--- a/backend/unpp_api/apps/agency/serializers.py
+++ b/backend/unpp_api/apps/agency/serializers.py
@@ -26,27 +26,3 @@ class AgencyOfficeSerializer(serializers.ModelSerializer):
     class Meta:
         model = AgencyOffice
         fields = ('id', 'name', 'countries_code',)
-
-
-class AgencyUserSerializer(serializers.ModelSerializer):
-
-    agency_name = serializers.SerializerMethodField()
-    office_name = serializers.SerializerMethodField()
-    role = serializers.SerializerMethodField()
-    name = serializers.CharField(source='get_fullname')
-
-    class Meta:
-        model = User
-        fields = ('id', 'agency_name', 'name', 'role', 'office_name',)
-
-    def _agency_member(self, obj):
-        return obj.agency_members.get()
-
-    def get_role(self, obj):
-        return self._agency_member(obj).get_role_display()
-
-    def get_agency_name(self, obj):
-        return self._agency_member(obj).office.agency.name
-
-    def get_office_name(self, obj):
-        return self._agency_member(obj).office.name

--- a/backend/unpp_api/apps/agency/views.py
+++ b/backend/unpp_api/apps/agency/views.py
@@ -8,8 +8,8 @@ from django_filters.rest_framework import DjangoFilterBackend
 from common.paginations import MediumPagination
 from common.permissions import IsAtLeastMemberReader
 from account.models import User
-from .serializers import (AgencySerializer, AgencyOfficeSerializer,
-                          AgencyUserSerializer)
+from account.serializers import AgencyUserSerializer
+from .serializers import AgencySerializer, AgencyOfficeSerializer
 from .models import Agency, AgencyOffice
 from .filters import AgencyUserFilter
 

--- a/backend/unpp_api/apps/partner/serializers.py
+++ b/backend/unpp_api/apps/partner/serializers.py
@@ -61,6 +61,7 @@ class PartnerMemberSerializer(serializers.ModelSerializer):
         fields = (
             'id',
             'title',
+            'role',
         )
 
 

--- a/backend/unpp_api/apps/review/serializers.py
+++ b/backend/unpp_api/apps/review/serializers.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from rest_framework import serializers
 
-from agency.serializers import AgencyUserSerializer
+from account.serializers import AgencyUserSerializer
 from .models import PartnerFlag, PartnerVerification
 
 


### PR DESCRIPTION
This adds a new view for accessing required details on the logged in user. 
`/api/accounts/me`

If the current user is a partner user, the following response will be returned:
```
{
    "id": 5,
    "name": "partner",
    "email": "fake-user-3@unicef.org",
    "partners": [
        {
            "id": 2,
            "legal_name": "legal name 1",
            "country_code": "AL"
        }
    ]
}
``` 
This includes all partners the user has access to (so all country partners if they are an HQ user). 

If the user is an agency user, the following will be returned:
```
{
    "id": 1,
    "name": "admin",
    "email": "admin@unicef.org",
    "agency_name": "UNICEF",
    "role": "Administrator",
    "office_name": "agency office 0"
}
```

