### PR TITLE
#292 changing unsolicited CN endpoint

### DIFF
--- a/backend/unpp_api/apps/project/serializers.py
+++ b/backend/unpp_api/apps/project/serializers.py
@@ -143,11 +143,10 @@ class CreateUnsolicitedProjectSerializer(serializers.Serializer):
 
     @transaction.atomic
     def create(self, validated_data):
-        # TODO: Will need to get the current partner from the header (since it can be switched as HQ user)
-        partner = PartnerMember.objects.get(user=self.context['request'].user).partner
+        partner = self.context['request'].active_partner
         app = Application.objects.create(
             is_unsolicited=True,
-            partner=partner,
+            partner_id=partner.id,
             eoi=None,
             agency_id=validated_data['agency'],
             submitter=self.context['request'].user,

--- a/backend/unpp_api/apps/project/tests/test_views.py
+++ b/backend/unpp_api/apps/project/tests/test_views.py
@@ -491,8 +491,9 @@ class TestCreateUnsolicitedProjectAPITestCase(BaseAPITestCase):
     quantity = 1
 
     def test_create(self):
-        url = reverse('projects:unsolicited')
+        url = reverse('projects:applications-unsolicited')
         filename = os.path.join(settings.PROJECT_ROOT, 'apps', 'common', 'tests', 'test.csv')
+        partner_id = Partner.objects.first().id
         with open(filename) as cn_template:
             payload = {
                 "locations": [
@@ -512,7 +513,8 @@ class TestCreateUnsolicitedProjectAPITestCase(BaseAPITestCase):
                 "specializations": Specialization.objects.all()[:3].values_list("id", flat=True),
                 "cn": cn_template,
             }
-            response = self.client.post(url, data=payload, format='multipart')
+            response = self.client.post(url, data=payload, format='multipart',
+                                        header={'Partner-ID': partner_id})
 
         self.assertTrue(statuses.is_success(response.status_code))
         app = Application.objects.last()

--- a/backend/unpp_api/apps/project/views.py
+++ b/backend/unpp_api/apps/project/views.py
@@ -295,17 +295,12 @@ class ReviewerAssessmentsAPIView(ListCreateAPIView, RetrieveUpdateAPIView):
         return super(ReviewerAssessmentsAPIView, self).update(request, application_id, *args, **kwargs)
 
 
-class UnsolicitedProjectAPIView(ListCreateAPIView):
-    parser_classes = (MultiPartParser, FormParser)
+class UnsolicitedProjectAPIView(ListAPIView):
     permission_classes = (IsAuthenticated, )
     queryset = Application.objects.filter(is_unsolicited=True)
     pagination_class = SmallPagination
     filter_class = ApplicationsUnsolicitedFilter
-
-    def get_serializer_class(self, *args, **kwargs):
-        if self.request.method == 'POST':
-            return CreateUnsolicitedProjectSerializer
-        return AgencyUnsolicitedApplicationSerializer
+    serializer_class = AgencyUnsolicitedApplicationSerializer
 
 
 class AppsPartnerOpenAPIView(ListAPIView):
@@ -320,10 +315,18 @@ class AppsPartnerOpenAPIView(ListAPIView):
         return self.queryset.filter(partner_id=self.request.active_partner)
 
 
-class AppsPartnerUnsolicitedAPIView(AppsPartnerOpenAPIView):
+class AppsPartnerUnsolicitedAPIView(ListCreateAPIView):
+    permission_classes = (IsAuthenticated, IsPartner)
+    parser_classes = (MultiPartParser, FormParser)
     queryset = Application.objects.filter(is_unsolicited=True)
-    serializer_class = ApplicationPartnerUnsolicitedDirectSerializer
     filter_class = ApplicationsUnsolicitedFilter
+    pagination_class = SmallPagination
+    filter_backends = (DjangoFilterBackend, )
+
+    def get_serializer_class(self, *args, **kwargs):
+        if self.request.method == 'POST':
+            return CreateUnsolicitedProjectSerializer
+        return ApplicationPartnerUnsolicitedDirectSerializer
 
 
 class AppsPartnerDirectAPIView(AppsPartnerUnsolicitedAPIView):


### PR DESCRIPTION
- UCN endpoint change
- Change default partner to active_partner

This follows up on comments from slack

```
Currently, we have:
1. `/api/projects/unsolicited/` - this is the create view for partners to create unsolicited cn
2. `/api/projects/applications/unsolicited/` - this is the view for partners to read/get their unsolicited concept notes.

It makes more sense to have partners create/get at 2 and leave 1 just for agencies to read
```

Additionally, completed TODO for active_partner in request vs. current user partner setting


