### PR TITLE
Feature/#327 pinned to details

### DIFF
--- a/backend/unpp_api/apps/project/tests/test_views.py
+++ b/backend/unpp_api/apps/project/tests/test_views.py
@@ -89,10 +89,12 @@ class TestOpenProjectsAPITestCase(BaseAPITestCase):
 
     quantity = 2
     url = reverse('projects:open')
+    user_type = 'agency'
 
     def setUp(self):
         super(TestOpenProjectsAPITestCase, self).setUp()
         AgencyMemberFactory.create_batch(self.quantity)
+        PartnerMemberFactory.create_batch(self.quantity)
         EOIFactory.create_batch(self.quantity)
 
     def test_open_project(self):

--- a/backend/unpp_api/apps/project/views.py
+++ b/backend/unpp_api/apps/project/views.py
@@ -29,6 +29,7 @@ from .serializers import (
     BaseProjectSerializer,
     DirectProjectSerializer,
     CreateProjectSerializer,
+    PartnerProjectSerializer,
     CreateDirectProjectSerializer,
     ProjectUpdateSerializer,
     ApplicationFullSerializer,
@@ -82,6 +83,11 @@ class EOIAPIView(RetrieveUpdateAPIView):
     permission_classes = (IsAuthenticated, IsAtLeastMemberEditor)
     serializer_class = ProjectUpdateSerializer
     queryset = EOI.objects.all()
+
+    def get_serializer_class(self, *args, **kwargs):
+        if self.request.user.is_agency_user:
+            return ProjectUpdateSerializer
+        return PartnerProjectSerializer
 
 
 class DirectProjectAPIView(BaseProjectAPIView):

--- a/frontend/src/reducers/cfeiDetails.js
+++ b/frontend/src/reducers/cfeiDetails.js
@@ -30,8 +30,8 @@ export const loadCfei = id => (dispatch) => {
 
 const saveCfei = (state, action) => {
   let cfei = normalizeSingleCfei(action.cfei);
-  cfei = R.assoc('reviewers', cfei.reviewers.map(String), cfei);
-  cfei = R.assoc('focal_points', cfei.focal_points.map(String), cfei);
+  if (cfei.reviewers) cfei = R.assoc('reviewers', cfei.reviewers.map(String), cfei);
+  if (cfei.focal_points) cfei = R.assoc('focal_points', cfei.focal_points.map(String), cfei);
   return R.assoc(cfei.id, cfei, state);
 };
 


### PR DESCRIPTION
This adds a different serializer for project details (/api/projects/:id/) for a partner user. What was added specially was:

```
    "is_pinned": false,
    "application": {
        "id": 2,
        "cn": null,
        "created": "2017-10-20T06:38:15.506484"
    }
```
If application wasn't submitted, it will return null. This may be easier to use vs. having to fetch a separate endpoint (as we do now) cc @marcindo @kenzo23312 
