### PR TITLE
gunicorn update for master

### DIFF
--- a/backend/requirements/base.pip
+++ b/backend/requirements/base.pip
@@ -25,6 +25,7 @@ requests==2.18.4
 python-dateutil==2.6.1
 django-imagekit==4.0.1
 XlsxWriter==1.0.2
+dj-static==0.0.6
 
 # Testing
 astroid==1.5.2
@@ -34,7 +35,7 @@ factory_boy==2.8.1
 mock==2.0.0
 
 # WSGI
-uwsgi==2.0.15
+gunicorn==19.6.0
 
 # Sentry
 raven==6.4.0

--- a/backend/unpp_api/wsgi.py
+++ b/backend/unpp_api/wsgi.py
@@ -10,7 +10,9 @@ https://docs.djangoproject.com/en/1.9/howto/deployment/wsgi/
 import os
 
 from django.core.wsgi import get_wsgi_application
+from dj_static import Cling
+
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "unpp_api.settings")
 
-application = get_wsgi_application()
+application = Cling(get_wsgi_application())


### PR DESCRIPTION
Currently to run the app in Rancher we need to put the proxy behind the proxy to make it run…

We recommend going with gunicorn.. as this enables us to get around uwsgi and run in prod with haproxy.

Static files are now also served with dj-static.

This PR will most likely break something else.. so.. just for ideas… (we got this running nicely in UAT after we got some ssl errors from the nginx proxy)